### PR TITLE
Fix compatibility streaming mode under Windows

### DIFF
--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -285,7 +285,7 @@ def download_rendition(rendition_uri, video_id):
         match = re.match('#EXT-X-KEY:METHOD=AES-128,URI="(https://.+?)"', line)
         if match:
             key_url = match.group(1)
-            key_path = os.path.join(temp_dir, "keyfile_%s.key" % md5(key_url).hexdigest())
+            key_path = os.path.join(temp_dir, "keyfile_%s.key" % md5(key_url).hexdigest()).replace('\\', '\\\\')
             keys.append((key_path, key_url))
             rendition_m3u8_file.write('#EXT-X-KEY:METHOD=AES-128,URI="%s"\n' % key_path)
         else:


### PR DESCRIPTION
The backslashes in the m3u8 file are treated as escapes by ffmpeg, resulting in log errors like this:
'ERROR: ffmpeg[FC8]: Unable to open key file C:UsersGlennAppDataRoamingKodicacheplugin.video.plus7brightcove_4898696667001keyfile_f9a471cf9107f4a24c22eb7ef9e42eb7.key'

I've ran into this a few times during fresh Kodi installs on Windows and keep forgetting that the default stream handling method is the compatibility mode. Hopefully this will save a few headaches as Kodi doesn't throw an error in the UI, the video just doesn't play.